### PR TITLE
Set up AITestKit project structure and configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "aitestkit"
+version = "1.0.0"
+description = "AI-Powered Test Development Toolkit"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+keywords = ["testing", "ai", "automation", "claude", "qa"]
+
+dependencies = [
+    "anthropic>=0.40.0",
+    "click>=8.1.0",
+    "pyyaml>=6.0",
+    "rich>=13.0.0",
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.1.0",
+    "black>=24.0.0",
+    "mypy>=1.0.0",
+]
+
+[project.scripts]
+aitestkit = "aitestkit.cli:main"
+
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true


### PR DESCRIPTION
Configure project metadata, dependencies, and dev tools:
- Core deps: anthropic, click, pyyaml, rich, pydantic, python-dotenv
- Dev deps: pytest, pytest-cov, ruff, black, mypy
- Tool configs for ruff, black, mypy with Python 3.11 target
- CLI entry point: aitestkit = aitestkit.cli:main